### PR TITLE
fix: CI 워크플로우를 참고용 템플릿으로 변경

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,115 +1,83 @@
-name: CI Pipeline
-
 # =============================================================================
-# OpenTraum — CI/CD Template
+# OpenTraum — CI/CD Template (참고용)
 # =============================================================================
-# Skeleton workflow for building, testing, and publishing Docker images.
-# Each microservice repository should copy and customize this template.
+# 이 파일은 각 마이크로서비스 레포지토리에서 복사하여 사용하는 템플릿입니다.
+# Infra 레포에서는 직접 실행하지 않습니다.
 # =============================================================================
-
-on:
-  push:
-    branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
-
-env:
-  JAVA_VERSION: "21"
-  DOCKER_REGISTRY: ghcr.io
-  IMAGE_PREFIX: opentraum
-
-jobs:
-  # ---------------------------------------------------------------------------
-  # Build & Test
-  # ---------------------------------------------------------------------------
-  build:
-    name: Build & Test
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: temurin
-          cache: gradle
-
-      - name: Grant execute permission for Gradlew
-        run: chmod +x gradlew
-
-      - name: Build with Gradle
-        run: ./gradlew build -x test
-
-      - name: Run tests
-        run: ./gradlew test
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results
-          path: build/reports/tests/
-          retention-days: 7
-
-  # ---------------------------------------------------------------------------
-  # Docker Build & Push (only on main/develop push)
-  # ---------------------------------------------------------------------------
-  docker:
-    name: Docker Build & Push
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'push'
-
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v4
-
-      - name: Set up JDK ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: temurin
-          cache: gradle
-
-      - name: Grant execute permission for Gradlew
-        run: chmod +x gradlew
-
-      - name: Build JAR
-        run: ./gradlew bootJar
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}
-          tags: |
-            type=ref,event=branch
-            type=sha,prefix=
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+#
+# 사용법: 각 서비스 레포에 .github/workflows/ci.yml로 복사 후,
+#         SERVICE_NAME 등을 해당 서비스에 맞게 수정하세요.
+#
+# name: CI Pipeline
+#
+# on:
+#   push:
+#     branches: [main, develop]
+#   pull_request:
+#     branches: [main, develop]
+#
+# env:
+#   JAVA_VERSION: "21"
+#   DOCKER_REGISTRY: ghcr.io
+#   IMAGE_PREFIX: opentraum
+#
+# jobs:
+#   build:
+#     name: Build & Test
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#       - uses: actions/setup-java@v4
+#         with:
+#           java-version: ${{ env.JAVA_VERSION }}
+#           distribution: temurin
+#           cache: gradle
+#       - run: chmod +x gradlew
+#       - run: ./gradlew build -x test
+#       - run: ./gradlew test
+#       - uses: actions/upload-artifact@v4
+#         if: always()
+#         with:
+#           name: test-results
+#           path: build/reports/tests/
+#           retention-days: 7
+#
+#   docker:
+#     name: Docker Build & Push
+#     runs-on: ubuntu-latest
+#     needs: build
+#     if: github.event_name == 'push'
+#     permissions:
+#       contents: read
+#       packages: write
+#     steps:
+#       - uses: actions/checkout@v4
+#       - uses: actions/setup-java@v4
+#         with:
+#           java-version: ${{ env.JAVA_VERSION }}
+#           distribution: temurin
+#           cache: gradle
+#       - run: chmod +x gradlew
+#       - run: ./gradlew bootJar
+#       - uses: docker/setup-buildx-action@v3
+#       - uses: docker/login-action@v3
+#         with:
+#           registry: ${{ env.DOCKER_REGISTRY }}
+#           username: ${{ github.actor }}
+#           password: ${{ secrets.GITHUB_TOKEN }}
+#       - id: meta
+#         uses: docker/metadata-action@v5
+#         with:
+#           images: ${{ env.DOCKER_REGISTRY }}/${{ github.repository }}
+#           tags: |
+#             type=ref,event=branch
+#             type=sha,prefix=
+#             type=raw,value=latest,enable={{is_default_branch}}
+#       - uses: docker/build-push-action@v6
+#         with:
+#           context: .
+#           push: true
+#           tags: ${{ steps.meta.outputs.tags }}
+#           labels: ${{ steps.meta.outputs.labels }}
+#           cache-from: type=gha
+#           cache-to: type=gha,mode=max


### PR DESCRIPTION
## 개요
Infra 레포에 Gradle 프로젝트가 없어 CI Pipeline이 실패하는 문제 수정.

워크플로우 전체를 주석 처리하여 각 마이크로서비스에서 복사해서 쓸 수 있는 참고용 템플릿으로 전환합니다.

## 테스트 계획
- [ ] develop push 시 CI 실행되지 않는 것 확인