### PR TITLE
fix: 게이트웨이 라우팅 보완 + Dockerfile.web 캐시 제어

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,7 +149,7 @@ services:
       SPRING_CLOUD_GATEWAY_ROUTES_1_PREDICATES_0: Path=/api/v1/users/**,/api/v1/tenants/**
       SPRING_CLOUD_GATEWAY_ROUTES_2_ID: event-service
       SPRING_CLOUD_GATEWAY_ROUTES_2_URI: http://event-service:8083
-      SPRING_CLOUD_GATEWAY_ROUTES_2_PREDICATES_0: Path=/api/v1/concerts/**,/api/v1/schedules/**,/api/v1/admin/seats/**
+      SPRING_CLOUD_GATEWAY_ROUTES_2_PREDICATES_0: Path=/api/v1/concerts/**,/api/v1/schedules/**,/api/v1/admin/seats/**,/api/v1/admin/events/**,/api/v1/admin/venues/**
       SPRING_CLOUD_GATEWAY_ROUTES_3_ID: reservation-service
       SPRING_CLOUD_GATEWAY_ROUTES_3_URI: http://reservation-service:8084
       SPRING_CLOUD_GATEWAY_ROUTES_3_PREDICATES_0: Path=/api/v1/reservations/**,/api/v1/queue/**,/api/v1/live/**,/api/v1/lottery/**
@@ -271,6 +271,8 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
+      # OpenAI (AI 이벤트 생성)
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -17,25 +17,25 @@ FROM nginx:alpine
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# nginx.conf는 docker-compose volume mount 또는 별도 COPY로 제공
-# 기본 설정: SPA fallback + API 프록시
-RUN echo 'server { \n\
-    listen 3000; \n\
-    server_name localhost; \n\
-    root /usr/share/nginx/html; \n\
-    index index.html; \n\
-    location / { try_files $uri $uri/ /index.html; } \n\
-    location /api/ { \n\
-        proxy_pass http://gateway:8080; \n\
-        proxy_set_header Host $host; \n\
-        proxy_set_header X-Real-IP $remote_addr; \n\
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; \n\
-        proxy_http_version 1.1; \n\
-        proxy_read_timeout 300s; \n\
-    } \n\
-    gzip on; \n\
-    gzip_types text/plain text/css application/json application/javascript text/xml; \n\
-}' > /etc/nginx/conf.d/default.conf
+# SPA fallback + API 프록시
+RUN printf 'server {\n\
+    listen 3000;\n\
+    server_name localhost;\n\
+    root /usr/share/nginx/html;\n\
+    index index.html;\n\
+    location / { try_files $uri $uri/ /index.html; }\n\
+    location = /index.html { add_header Cache-Control "no-cache, no-store, must-revalidate"; }\n\
+    location /api/ {\n\
+        proxy_pass http://gateway:8080;\n\
+        proxy_set_header Host $host;\n\
+        proxy_set_header X-Real-IP $remote_addr;\n\
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n\
+        proxy_http_version 1.1;\n\
+        proxy_read_timeout 300s;\n\
+    }\n\
+    gzip on;\n\
+    gzip_types text/plain text/css application/json application/javascript text/xml;\n\
+}\n' > /etc/nginx/conf.d/default.conf
 
 EXPOSE 3000
 


### PR DESCRIPTION
## 개요
Web #20 관련 인프라 수정

## 변경 사항
| 파일 | 변경 내용 |
|---|---|
| `docker-compose.yml` | event-service 게이트웨이 라우팅 보완 + OPENAI_API_KEY 환경변수 |
| `docker/Dockerfile.web` | index.html no-cache 헤더 추가 (리빌드 후 캐시 문제 해결) |