### PR TITLE
fix: opentraum-ingress TLS (Let's Encrypt) 설정 추가

### DIFF
--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -10,8 +10,13 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   ingressClassName: nginx
+  tls:
+    - hosts:
+        - skala3-cloud1-team8.cloud.skala-ai.com
+      secretName: opentraum-tls
   rules:
     - host: skala3-cloud1-team8.cloud.skala-ai.com
       http:


### PR DESCRIPTION
## 배경

ingress에 TLS 섹션 없음 → nginx default fake cert 반환 → 브라우저 TLS untrusted.

## 변경

- annotation `cert-manager.io/cluster-issuer: letsencrypt-prod`
- `spec.tls`에 host + secretName

## 검증

- Certificate Ready 11초 만에 True
- HTTPS 200, ssl_verify_result 0, Let's Encrypt R12 발급