### PR TITLE
chore: Debezium connector snapshot mode를 when_needed로 변경

### DIFF
--- a/k8s/kafka-connect/connector-event.yaml
+++ b/k8s/kafka-connect/connector-event.yaml
@@ -28,7 +28,7 @@ spec:
     schema.history.internal.kafka.bootstrap.servers: my-kafka-cluster-kafka-bootstrap.kafka:9092
     schema.history.internal.kafka.topic: schema-history.event
 
-    snapshot.mode: initial
+    snapshot.mode: when_needed
     include.schema.changes: "false"
     tombstones.on.delete: "false"
 

--- a/k8s/kafka-connect/connector-payment.yaml
+++ b/k8s/kafka-connect/connector-payment.yaml
@@ -28,7 +28,7 @@ spec:
     schema.history.internal.kafka.bootstrap.servers: my-kafka-cluster-kafka-bootstrap.kafka:9092
     schema.history.internal.kafka.topic: schema-history.payment
 
-    snapshot.mode: initial
+    snapshot.mode: when_needed
     include.schema.changes: "false"
     tombstones.on.delete: "false"
 

--- a/k8s/kafka-connect/connector-reservation.yaml
+++ b/k8s/kafka-connect/connector-reservation.yaml
@@ -31,7 +31,7 @@ spec:
     schema.history.internal.kafka.topic: schema-history.reservation
 
     # === Snapshot / internal topics ===
-    snapshot.mode: initial
+    snapshot.mode: when_needed
     include.schema.changes: "false"
     tombstones.on.delete: "false"
 


### PR DESCRIPTION
## 작업 내용

- event/payment/reservation Debezium connector의 `snapshot.mode`를 `initial`에서 `when_needed`로 변경했습니다.

## 배경 / 원인

connector 재시작 때마다 불필요한 initial snapshot을 반복하면 운영 중 CDC 재시작 비용과 schema/history 충돌 가능성이 커집니다. 기본 운영 모드는 기존 offset/schema history를 우선 사용하고 필요 시에만 snapshot하는 `when_needed`가 더 안전합니다.

## 팀 공유사항

- 오늘 event CDC는 `event.outbox_events` schema history mismatch로 task failed 상태가 되었고, 클러스터에는 `snapshot.mode=recovery` 임시 적용 후 `when_needed`로 되돌리는 방식으로 복구했습니다.
- 현재 클러스터의 세 KafkaConnector는 모두 READY `True`입니다.
- 이 PR은 recovery 절차 자체가 아니라 운영 manifest의 snapshot mode를 `when_needed`로 맞추는 변경입니다.
- ArgoCD automated sync/selfHeal은 복구되어 현재 클러스터는 GitOps 기준으로 자동 회복됩니다.
- 수동 배포 이미지 기준 E2E/API는 `74/74` 통과했지만, 이후 ArgoCD selfHeal 복구로 현재 클러스터 이미지는 GitOps 기준 이미지로 되돌아간 상태입니다.

## 검증

- K8s에서 `event-outbox-connector`, `payment-outbox-connector`, `reservation-outbox-connector` READY `True` 확인
- ArgoCD Application `Synced/Healthy` 확인
- 세 서비스 rollout 완료 확인

## 영향 범위

- Debezium MariaDB KafkaConnector snapshot 동작
- CDC 재시작/복구 운영 안정성

## 관련 이슈

- Related: CDC 운영 안정화
