### PR TITLE
fix: monitoring DaemonSet 스케줄링 평탄화

### DIFF
--- a/docs/OPENTRAUM-INFRA-05-MONITORING.md
+++ b/docs/OPENTRAUM-INFRA-05-MONITORING.md
@@ -36,8 +36,10 @@
 - 매니페스트와 values 파일:
   - `k8s/monitoring/values-kube-prometheus-stack.yaml`
   - `k8s/monitoring/values-loki.yaml`
+  - `k8s/monitoring/values-alloy.yaml`
   - `k8s/monitoring/README.md`
-  - `k8s/alloy/configmap-patch.yaml`
+  - `k8s/gpu-monitoring/nvidia-device-plugin.yml`
+  - `k8s/gpu-monitoring/dcgm-exporter.yml`
 
 ---
 
@@ -220,7 +222,7 @@ PVC 라이브 인벤토리는 다음과 같습니다.
 |---|---|---|---|
 | `storage-loki-0` | 10Gi | RWO | `ebs-sc` |
 
-DaemonSet 인 alloy 와 loki-canary 는 일반 워커 노드에서 기동되며, taint 가 걸린 g5 노드는 회피합니다. 본문에서는 "노드당 1 Pod (DaemonSet)" 으로 표기합니다.
+DaemonSet 인 alloy 와 loki-canary 는 일반 워커 노드그룹(`skala3-cloud1-team8-ng`)에서만 기동됩니다. GPU 노드는 `nvidia-device-plugin` 과 `dcgm-exporter` 가 담당하며, 일반 로그 수집 DaemonSet 이 GPU 노드의 Pod slot 을 사용하지 않도록 분리합니다. 본문에서는 "노드당 1 Pod (DaemonSet)" 으로 표기합니다.
 
 ---
 
@@ -355,7 +357,7 @@ Alloy 는 `loki-gateway` (`http://loki-gateway.monitoring.svc.cluster.local/loki
 
 ## 8. Alloy DaemonSet과 로그 수집 흐름
 
-Alloy 는 노드당 1 Pod 의 DaemonSet 입니다. `configmap-patch.yaml` 은 chart 가 만든 기본 alloy ConfigMap 을 통째로 덮어쓰는 patch 매니페스트로, Pod 로그 수집 파이프라인을 정의합니다.
+Alloy 는 일반 워커 노드당 1 Pod 의 DaemonSet 입니다. `values-alloy.yaml` 은 chart values 로 Pod 로그 수집 파이프라인과 일반 워커 노드 배치 기준을 함께 정의합니다. `alloy/configmap-patch.yaml` 은 수동 ConfigMap 패치가 필요할 때 참고하는 보조 파일입니다.
 
 ```
 discovery.kubernetes "pods"  -> Pod 자원 watch

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -19,7 +19,9 @@ k8s/
 ├── kafka-connect/           Strimzi KafkaConnect + Connectors + Topics
 ├── redis/                   opentraum-redis (priorityClass: high)
 │
-└── alloy/                   Grafana Alloy config patch (로그 수집)
+├── monitoring/              Helm values (Prometheus / Loki / Alloy)
+├── gpu-monitoring/          NVIDIA device plugin / DCGM exporter / GPU dashboard
+└── alloy/                   Grafana Alloy 수동 ConfigMap patch 참고용
 ```
 
 ## Kafka — Strimzi `my-kafka-cluster` 사용
@@ -63,7 +65,17 @@ kubectl apply -f redis/
 bash kafka-connect/deploy.sh
 
 # 5. 모니터링
-kubectl apply -f alloy/
+kubectl apply -f gpu-monitoring/nvidia-device-plugin.yml
+kubectl apply -f gpu-monitoring/dcgm-exporter.yml
+
+helm upgrade kube-prometheus-stack prometheus-community/kube-prometheus-stack \
+  -n monitoring -f monitoring/values-kube-prometheus-stack.yaml
+
+helm upgrade loki grafana/loki \
+  -n monitoring -f monitoring/values-loki.yaml
+
+helm upgrade alloy grafana/alloy \
+  -n monitoring -f monitoring/values-alloy.yaml
 
 # 6. 앱: 각 서비스 레포 `k8s/` 가 SoT. ArgoCD Application 이 자동 sync.
 #    DB Secret (auth-db-secret, user-db-secret, event-db-secret, reservation-db-secret, payment-db-secret) 은

--- a/k8s/alloy/configmap-patch.yaml
+++ b/k8s/alloy/configmap-patch.yaml
@@ -3,6 +3,8 @@
 #
 # 기존 Helm chart가 생성한 alloy ConfigMap을 완전히 대체합니다.
 # Kubernetes Pod 로그 수집(Loki push) 블록만 정의합니다.
+# 정식 배포는 k8s/monitoring/values-alloy.yaml 로 관리하고,
+# 이 파일은 수동 ConfigMap 패치가 필요할 때만 사용합니다.
 #
 # 주의: 이 파일 apply 후 alloy DaemonSet/Deployment를 rollout restart 해야
 #       새 config가 반영됩니다.
@@ -41,6 +43,10 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_part_of"]
+        target_label  = "project"
       }
     }
 

--- a/k8s/gpu-monitoring/nvidia-device-plugin.yml
+++ b/k8s/gpu-monitoring/nvidia-device-plugin.yml
@@ -1,0 +1,74 @@
+---
+# NVIDIA device plugin
+#
+# GPU 노드에서만 nvidia.com/gpu 리소스를 광고합니다.
+# 일반 t3 노드에 뜨면 불필요하게 Pod slot을 사용하므로 nodeSelector로 제한합니다.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nvidia-device-plugin-config
+  namespace: kube-system
+data:
+  config.yaml: |
+    version: v1
+    sharing:
+      timeSlicing:
+        renameByDefault: false
+        failRequestsGreaterThanOne: false
+        resources:
+          - name: nvidia.com/gpu
+            replicas: 2
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin-daemonset
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: nvidia-device-plugin-ds
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: nvidia-device-plugin-ds
+    spec:
+      nodeSelector:
+        nodegroup-type: gpu
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+        - key: nodegroup-type
+          operator: Equal
+          value: gpu
+          effect: NoSchedule
+      containers:
+        - name: nvidia-device-plugin-ctr
+          image: nvcr.io/nvidia/k8s-device-plugin:v0.17.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config-file=/etc/nvidia-device-plugin/config.yaml
+          env:
+            - name: FAIL_ON_INIT_ERROR
+              value: "false"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: nvidia-device-plugin-config
+              mountPath: /etc/nvidia-device-plugin
+              readOnly: true
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: nvidia-device-plugin-config
+          configMap:
+            name: nvidia-device-plugin-config

--- a/k8s/monitoring/README.md
+++ b/k8s/monitoring/README.md
@@ -6,17 +6,17 @@ monitoring ns 의 Helm release 3개에 대한 values.yaml 모음.
 
 | Release | Chart | Version | 주요 역할 |
 |---|---|---|---|
-| `kube-prometheus-stack` | `prometheus-community/kube-prometheus-stack` | 82.16.2 | Prometheus + Alertmanager + Grafana + Operator + kube-state-metrics |
-| `loki` | `grafana/loki` | 6.55.0 | 로그 저장 (SingleBinary) + gateway |
-| `alloy` | `grafana/alloy` | 1.7.0 | 로그 수집 (DaemonSet), values 파일 불필요 |
+| `kube-prometheus-stack` | `prometheus-community/kube-prometheus-stack` | 84.3.0 | Prometheus + Alertmanager + Grafana + Operator + kube-state-metrics |
+| `loki` | `grafana/loki` | 7.0.0 | 로그 저장 (SingleBinary) + gateway + canary |
+| `alloy` | `grafana/alloy` | 1.7.0 | 로그 수집 (DaemonSet), 일반 워커 노드 배치 |
 
 ## 파일
 
 | 파일 | 대상 |
 |---|---|
 | `values-kube-prometheus-stack.yaml` | kube-prometheus-stack 전체 |
-| `values-loki.yaml` | loki singleBinary + gateway |
-| (alloy) | DaemonSet 이라 자동 분산, 별도 values 없음. 필요 시 `alloy/configmap-patch.yaml` 참고 |
+| `values-loki.yaml` | loki singleBinary + gateway + loki-canary |
+| `values-alloy.yaml` | alloy 로그 수집 + 일반 워커 노드 배치 |
 
 ## 적용
 
@@ -32,6 +32,9 @@ helm upgrade kube-prometheus-stack prometheus-community/kube-prometheus-stack \
 
 helm upgrade loki grafana/loki \
   -n monitoring -f values-loki.yaml
+
+helm upgrade alloy grafana/alloy \
+  -n monitoring -f values-alloy.yaml
 ```
 
 ## 주요 설계 결정
@@ -60,10 +63,12 @@ helm upgrade loki grafana/loki \
 - EBS CSI 는 AZ-bound. Loki singleBinary PVC 가 2a/2b 중 하나에 바인딩되면 해당 AZ 3노드 중에서만 스케줄 가능
 - `replicas=1` 이므로 분산 효과 제한적. 주 목적은 "특정 노드에 집중되지 않게" 힌트 제공
 
-### alloy 제외 이유
+### DaemonSet 스케줄링 기준
 
-- DaemonSet 이라 각 노드당 1개씩 자동 분산
-- `alloy/configmap-patch.yaml` 로 Loki push 파이프라인을 별도 관리
+- `alloy` 와 `loki-canary` 는 일반 워커 노드그룹(`skala3-cloud1-team8-ng`)에만 배치
+- GPU 노드의 GPU 메트릭은 `gpu-monitoring/dcgm-exporter.yml` 이 별도 수집
+- `nvidia-device-plugin` 은 GPU 노드에서만 `nvidia.com/gpu` 리소스를 광고
+- 기존 `alloy/configmap-patch.yaml` 은 수동 ConfigMap 패치용 참고 파일이며, 정식 배포는 `values-alloy.yaml` 로 관리
 
 ## 히스토리
 

--- a/k8s/monitoring/values-alloy.yaml
+++ b/k8s/monitoring/values-alloy.yaml
@@ -1,0 +1,56 @@
+# Alloy values.yaml
+#
+# Helm release: alloy (chart 1.7.0, app v1.15.0)
+# 설치 ns: monitoring
+#
+# alloy는 노드 로그 수집 DaemonSet입니다.
+# GPU 노드는 dcgm-exporter가 별도로 수집하므로 일반 워커 노드에서만 기동합니다.
+
+controller:
+  type: daemonset
+  nodeSelector:
+    eks.amazonaws.com/nodegroup: skala3-cloud1-team8-ng
+  tolerations: []
+
+alloy:
+  configMap:
+    content: |
+      discovery.kubernetes "pods" {
+        role = "pod"
+      }
+
+      discovery.relabel "pods" {
+        targets = discovery.kubernetes.pods.targets
+
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label  = "namespace"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_name"]
+          target_label  = "pod"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_container_name"]
+          target_label  = "container"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          target_label  = "app"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_part_of"]
+          target_label  = "project"
+        }
+      }
+
+      loki.source.kubernetes "pods" {
+        targets    = discovery.relabel.pods.output
+        forward_to = [loki.write.default.receiver]
+      }
+
+      loki.write "default" {
+        endpoint {
+          url = "http://loki-gateway.monitoring.svc.cluster.local/loki/api/v1/push"
+        }
+      }

--- a/k8s/monitoring/values-kube-prometheus-stack.yaml
+++ b/k8s/monitoring/values-kube-prometheus-stack.yaml
@@ -1,6 +1,6 @@
 # kube-prometheus-stack values.yaml
 #
-# Helm release: kube-prometheus-stack (chart 82.16.2, app v0.89.0)
+# Helm release: kube-prometheus-stack (chart 84.3.0, app v0.90.1)
 # 설치 ns: monitoring
 #
 # 주요 변경 (2026-04-22):

--- a/k8s/monitoring/values-loki.yaml
+++ b/k8s/monitoring/values-loki.yaml
@@ -1,6 +1,6 @@
 # Loki values.yaml
 #
-# Helm release: loki (chart 6.55.0, app 3.6.7)
+# Helm release: loki (chart 7.0.0, app 3.6.7)
 # 설치 ns: monitoring
 # Mode: SingleBinary (단일 Pod + filesystem storage)
 #
@@ -96,6 +96,11 @@ gateway:
     limits:
       memory: 128Mi
       cpu: 100m
+
+lokiCanary:
+  nodeSelector:
+    eks.amazonaws.com/nodegroup: skala3-cloud1-team8-ng
+  tolerations: []
 
 # 기본 비활성 컴포넌트 (SingleBinary 모드)
 resultsCache:


### PR DESCRIPTION
Closes #38

## 배경

monitoring DaemonSet과 NVIDIA device plugin이 모든 노드를 대상으로 동작하면서 일반 워커 노드의 Pod slot이 부족해지는 문제가 있었습니다.

## 변경

- `nvidia-device-plugin`을 GPU 노드(`nodegroup-type=gpu`)에만 배치
- `alloy`, `loki-canary`를 일반 워커 노드그룹(`skala3-cloud1-team8-ng`)에만 배치
- Alloy 정식 배포 기준을 `values-alloy.yaml`로 추가
- monitoring/gpu 관련 README와 운영 문서 정합성 정리

## 검증

- YAML 파싱 확인
- Helm template 확인: alloy 1.7.0, loki 7.0.0
- 클러스터 적용 확인
  - `nvidia-device-plugin-daemonset`: 3/3 Ready
  - `alloy`: 7/7 Ready
  - `loki-canary`: 7/7 Ready
  - Pending Pod 없음

## 운영 반영

- `helm upgrade alloy ... -f k8s/monitoring/values-alloy.yaml` 적용
- `helm upgrade loki ... -f k8s/monitoring/values-loki.yaml` 적용
- 과거 수동 패치로 남아 있던 GPU toleration 제거
