### PR TITLE
fix: #41 monitoring Helm 정리 및 loki-canary 제거

### DIFF
--- a/docs/OPENTRAUM-INFRA-00-INDEX.md
+++ b/docs/OPENTRAUM-INFRA-00-INDEX.md
@@ -61,7 +61,7 @@ OpenTraum 의 EKS 인프라(클러스터, 네트워크, 워크로드, 데이터,
 | CDC | Debezium MariaDB 3.2.0 + Outbox EventRouter SMT |
 | GitOps | ArgoCD v3.3.6 (Application 7개, 모두 Synced/Healthy) |
 | 이미지 레지스트리 | Harbor (<HARBOR_REGISTRY> / project <HARBOR_PROJECT>) |
-| 모니터링 | Prometheus v3.11.3, Grafana 13.0.1, Loki 3.6.7, Alloy v1.15.0 |
+| 모니터링 | Prometheus v3.11.3, Grafana 13.0.1, Loki 3.6.7, Alloy v1.16.0 |
 
 ## 3.5 정량 성과 한눈에 보기
 

--- a/docs/OPENTRAUM-INFRA-05-MONITORING.md
+++ b/docs/OPENTRAUM-INFRA-05-MONITORING.md
@@ -180,21 +180,20 @@ monitoring 네임스페이스에 설치된 Helm release 와 라이브 Pod 이미
 
 | Release | Chart 버전 | App 버전 | 역할 |
 |---|---|---|---|
-| `kube-prometheus-stack` | 84.3.0 | v0.90.1 | Prometheus, Alertmanager, Grafana, Operator, kube-state-metrics 통합 |
+| `kube-prometheus-stack` | 84.4.0 | v0.90.1 | Prometheus, Alertmanager, Grafana, Operator, kube-state-metrics 통합 |
 | `loki` | 7.0.0 | 3.6.7 | 로그 저장(SingleBinary) + gateway |
-| `alloy` | 1.7.0 | v1.15.0 | 로그 수집(DaemonSet) |
+| `alloy` | 1.8.0 | v1.16.0 | 로그 수집(DaemonSet) |
 
 라이브 Pod 인벤토리(이미지 태그 포함) 는 다음과 같습니다.
 
 | Pod | 이미지 |
 |---|---|
 | `alertmanager-kube-prometheus-stack-alertmanager-0` (2/2) | `quay.io/prometheus/alertmanager:v0.32.0` + `quay.io/prometheus-operator/prometheus-config-reloader:v0.90.1` |
-| `alloy-*` (DaemonSet, 노드당 1 Pod, 2/2) | `docker.io/grafana/alloy:v1.15.0` + `quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0` |
+| `alloy-*` (DaemonSet, 노드당 1 Pod, 2/2) | `docker.io/grafana/alloy:v1.16.0` + `quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0` |
 | `kube-prometheus-stack-grafana-*` (3/3) | `quay.io/kiwigrid/k8s-sidecar:2.7.1` (×2) + `docker.io/grafana/grafana:13.0.1` |
 | `kube-prometheus-stack-kube-state-metrics-*` | `registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0` |
 | `kube-prometheus-stack-operator-*` | `quay.io/prometheus-operator/prometheus-operator:v0.90.1` |
 | `loki-0` (2/2) | `docker.io/grafana/loki:3.6.7` + `docker.io/kiwigrid/k8s-sidecar:2.5.0` |
-| `loki-canary-*` (DaemonSet, 노드당 1 Pod) | `docker.io/grafana/loki-canary:3.6.7` |
 | `loki-gateway-*` | `docker.io/nginxinc/nginx-unprivileged:1.29-alpine` |
 | `prometheus-kube-prometheus-stack-prometheus-0` (2/2) | `quay.io/prometheus/prometheus:v3.11.3` + `quay.io/prometheus-operator/prometheus-config-reloader:v0.90.1` |
 
@@ -210,7 +209,6 @@ Service 라이브 인벤토리는 다음과 같습니다.
 | `kube-prometheus-stack-prometheus` | 9090, 8080 |
 | `kube-prometheus-stack-prometheus-node-exporter` | 9100 |
 | `loki` | 3100, 9095 |
-| `loki-canary` | 3500 |
 | `loki-gateway` | 80 |
 | `loki-headless` | 3100 |
 | `loki-memberlist` | 7946 |
@@ -222,7 +220,9 @@ PVC 라이브 인벤토리는 다음과 같습니다.
 |---|---|---|---|
 | `storage-loki-0` | 10Gi | RWO | `ebs-sc` |
 
-DaemonSet 인 alloy 와 loki-canary 는 일반 워커 노드그룹(`skala3-cloud1-team8-ng`)에서만 기동됩니다. GPU 노드는 `nvidia-device-plugin` 과 `dcgm-exporter` 가 담당하며, 일반 로그 수집 DaemonSet 이 GPU 노드의 Pod slot 을 사용하지 않도록 분리합니다. 본문에서는 "노드당 1 Pod (DaemonSet)" 으로 표기합니다.
+DaemonSet 인 alloy 는 일반 워커 노드그룹(`skala3-cloud1-team8-ng`)에서만 기동됩니다. GPU 노드는 `nvidia-device-plugin` 과 `dcgm-exporter` 가 담당하며, 일반 로그 수집 DaemonSet 이 GPU 노드의 Pod slot 을 사용하지 않도록 분리합니다. `loki-canary` 는 실습용 검증 컴포넌트라 운영 배포에서는 비활성화합니다.
+
+GPU monitoring 리소스는 Helm release 에 포함하지 않고 `k8s/gpu-monitoring/` raw manifest 로 관리합니다. `dcgm-exporter.yml` 에 DaemonSet, Service, ServiceMonitor 가 함께 들어 있고, `grafana-dashboard.yml` 은 `grafana_dashboard: "1"` 라벨 ConfigMap 으로 Grafana sidecar 가 자동 등록합니다. 따라서 GPU 대시보드(`uid: opentraum-gpu`)를 복구할 때는 두 manifest 를 다시 적용하면 됩니다.
 
 ---
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -20,7 +20,7 @@ k8s/
 ├── redis/                   opentraum-redis (priorityClass: high)
 │
 ├── monitoring/              Helm values (Prometheus / Loki / Alloy)
-├── gpu-monitoring/          NVIDIA device plugin / DCGM exporter / GPU dashboard
+├── gpu-monitoring/          raw manifest (NVIDIA device plugin / DCGM exporter / GPU dashboard)
 └── alloy/                   Grafana Alloy 수동 ConfigMap patch 참고용
 ```
 
@@ -67,14 +67,18 @@ bash kafka-connect/deploy.sh
 # 5. 모니터링
 kubectl apply -f gpu-monitoring/nvidia-device-plugin.yml
 kubectl apply -f gpu-monitoring/dcgm-exporter.yml
+kubectl apply -f gpu-monitoring/grafana-dashboard.yml
 
 helm upgrade kube-prometheus-stack prometheus-community/kube-prometheus-stack \
+  --version 84.4.0 \
   -n monitoring -f monitoring/values-kube-prometheus-stack.yaml
 
 helm upgrade loki grafana/loki \
+  --version 7.0.0 \
   -n monitoring -f monitoring/values-loki.yaml
 
 helm upgrade alloy grafana/alloy \
+  --version 1.8.0 \
   -n monitoring -f monitoring/values-alloy.yaml
 
 # 6. 앱: 각 서비스 레포 `k8s/` 가 SoT. ArgoCD Application 이 자동 sync.

--- a/k8s/monitoring/README.md
+++ b/k8s/monitoring/README.md
@@ -6,16 +6,16 @@ monitoring ns 의 Helm release 3개에 대한 values.yaml 모음.
 
 | Release | Chart | Version | 주요 역할 |
 |---|---|---|---|
-| `kube-prometheus-stack` | `prometheus-community/kube-prometheus-stack` | 84.3.0 | Prometheus + Alertmanager + Grafana + Operator + kube-state-metrics |
-| `loki` | `grafana/loki` | 7.0.0 | 로그 저장 (SingleBinary) + gateway + canary |
-| `alloy` | `grafana/alloy` | 1.7.0 | 로그 수집 (DaemonSet), 일반 워커 노드 배치 |
+| `kube-prometheus-stack` | `prometheus-community/kube-prometheus-stack` | 84.4.0 | Prometheus + Alertmanager + Grafana + Operator + kube-state-metrics |
+| `loki` | `grafana/loki` | 7.0.0 | 로그 저장 (SingleBinary) + gateway |
+| `alloy` | `grafana/alloy` | 1.8.0 | 로그 수집 (DaemonSet), 일반 워커 노드 배치 |
 
 ## 파일
 
 | 파일 | 대상 |
 |---|---|
 | `values-kube-prometheus-stack.yaml` | kube-prometheus-stack 전체 |
-| `values-loki.yaml` | loki singleBinary + gateway + loki-canary |
+| `values-loki.yaml` | loki singleBinary + gateway |
 | `values-alloy.yaml` | alloy 로그 수집 + 일반 워커 노드 배치 |
 
 ## 적용
@@ -28,12 +28,15 @@ helm repo update
 
 # Upgrade
 helm upgrade kube-prometheus-stack prometheus-community/kube-prometheus-stack \
+  --version 84.4.0 \
   -n monitoring -f values-kube-prometheus-stack.yaml
 
 helm upgrade loki grafana/loki \
+  --version 7.0.0 \
   -n monitoring -f values-loki.yaml
 
 helm upgrade alloy grafana/alloy \
+  --version 1.8.0 \
   -n monitoring -f values-alloy.yaml
 ```
 
@@ -65,10 +68,17 @@ helm upgrade alloy grafana/alloy \
 
 ### DaemonSet 스케줄링 기준
 
-- `alloy` 와 `loki-canary` 는 일반 워커 노드그룹(`skala3-cloud1-team8-ng`)에만 배치
+- `alloy` 는 일반 워커 노드그룹(`skala3-cloud1-team8-ng`)에만 배치
+- `loki-canary` 는 실습용 검증 컴포넌트라 운영 배포에서는 비활성화
 - GPU 노드의 GPU 메트릭은 `gpu-monitoring/dcgm-exporter.yml` 이 별도 수집
 - `nvidia-device-plugin` 은 GPU 노드에서만 `nvidia.com/gpu` 리소스를 광고
 - 기존 `alloy/configmap-patch.yaml` 은 수동 ConfigMap 패치용 참고 파일이며, 정식 배포는 `values-alloy.yaml` 로 관리
+
+### GPU monitoring 관리 기준
+
+- `dcgm-exporter`, ServiceMonitor, GPU Grafana dashboard 는 `k8s/gpu-monitoring/` raw manifest 로 관리
+- Helm release(`kube-prometheus-stack`, `loki`, `alloy`) 는 core monitoring 구성만 관리
+- GPU dashboard 는 Grafana sidecar 가 `grafana_dashboard: "1"` 라벨 ConfigMap 을 watch 해서 자동 등록
 
 ## 히스토리
 

--- a/k8s/monitoring/values-alloy.yaml
+++ b/k8s/monitoring/values-alloy.yaml
@@ -1,6 +1,6 @@
 # Alloy values.yaml
 #
-# Helm release: alloy (chart 1.7.0, app v1.15.0)
+# Helm release: alloy (chart 1.8.0, app v1.16.0)
 # 설치 ns: monitoring
 #
 # alloy는 노드 로그 수집 DaemonSet입니다.

--- a/k8s/monitoring/values-kube-prometheus-stack.yaml
+++ b/k8s/monitoring/values-kube-prometheus-stack.yaml
@@ -1,6 +1,6 @@
 # kube-prometheus-stack values.yaml
 #
-# Helm release: kube-prometheus-stack (chart 84.3.0, app v0.90.1)
+# Helm release: kube-prometheus-stack (chart 84.4.0, app v0.90.1)
 # 설치 ns: monitoring
 #
 # 주요 변경 (2026-04-22):
@@ -12,7 +12,7 @@
 #   helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 #   helm repo update
 #   helm upgrade kube-prometheus-stack prometheus-community/kube-prometheus-stack \
-#     -n monitoring -f values-kube-prometheus-stack.yaml
+#     --version 84.4.0 -n monitoring -f values-kube-prometheus-stack.yaml
 
 # ===== Prometheus =====
 prometheus:

--- a/k8s/monitoring/values-loki.yaml
+++ b/k8s/monitoring/values-loki.yaml
@@ -13,7 +13,7 @@
 # 적용:
 #   helm repo add grafana https://grafana.github.io/helm-charts
 #   helm repo update
-#   helm upgrade loki grafana/loki -n monitoring -f values-loki.yaml
+#   helm upgrade loki grafana/loki --version 7.0.0 -n monitoring -f values-loki.yaml
 
 deploymentMode: SingleBinary
 
@@ -97,10 +97,14 @@ gateway:
       memory: 128Mi
       cpu: 100m
 
+# loki-canary 는 실습용 검증 컴포넌트라 운영 배포에서는 제외합니다.
+# enabled=false 로 유지해야 helm upgrade 이후에도 DaemonSet 이 재생성되지 않습니다.
 lokiCanary:
-  nodeSelector:
-    eks.amazonaws.com/nodegroup: skala3-cloud1-team8-ng
-  tolerations: []
+  enabled: false
+
+# 기본 Helm test 는 loki-canary metrics endpoint 를 참조하므로 함께 비활성화합니다.
+test:
+  enabled: false
 
 # 기본 비활성 컴포넌트 (SingleBinary 모드)
 resultsCache:


### PR DESCRIPTION
Closes #41

## 배경
- `loki-canary`는 실습용 검증 컴포넌트라 운영 배포에서 제거하기로 결정됨
- 단순 삭제만 하면 다음 `helm upgrade loki` 때 다시 생성될 수 있어 Loki values 기준 정리가 필요함
- GPU monitoring 리소스는 Helm release가 아니라 `k8s/gpu-monitoring/` raw manifest로 관리 중이라 관리 기준을 문서화할 필요가 있음

## 변경
- `values-loki.yaml`에서 `lokiCanary.enabled=false` 설정
- Loki chart의 기본 Helm test가 canary endpoint를 참조하므로 `test.enabled=false` 함께 설정
- monitoring/GPU monitoring README와 인프라 문서에서 `loki-canary` 운영 제외 기준 반영
- `dcgm-exporter`, ServiceMonitor, GPU Grafana dashboard의 raw manifest 관리 기준 명시
- 현재 live Helm chart 버전에 맞춰 upgrade 명령의 `--version` 고정

## 검증
- `helm template loki grafana/loki --version 7.0.0 -n monitoring -f k8s/monitoring/values-loki.yaml`
- rendered manifest에서 `loki-canary` 미생성 확인
- `helm upgrade loki grafana/loki --version 7.0.0 -n monitoring -f k8s/monitoring/values-loki.yaml`
- `kubectl -n monitoring get ds loki-canary` → NotFound
- `kubectl -n monitoring get svc loki-canary` → NotFound
- `kubectl -n gpu-monitoring get ds,svc,servicemonitor -o wide`
- GPU dashboard ConfigMap `uid: opentraum-gpu` 유지 확인
- `kubectl get pods -A --field-selector=status.phase=Pending` → No resources found
