### PR TITLE
fix: #44 Grafana OOM 503 방지

### DIFF
--- a/k8s/monitoring/values-kube-prometheus-stack.yaml
+++ b/k8s/monitoring/values-kube-prometheus-stack.yaml
@@ -104,10 +104,10 @@ grafana:
           app.kubernetes.io/name: grafana
   resources:
     requests:
-      memory: 128Mi
+      memory: 192Mi
       cpu: 50m
     limits:
-      memory: 256Mi
+      memory: 512Mi
       cpu: 300m
 
 # ===== Operator =====


### PR DESCRIPTION
Closes #44

## 배경
- Grafana 접속 시 `503 Service Temporarily Unavailable` 발생
- live Pod에서 `grafana` 컨테이너가 `OOMKilled`로 재시작된 이력 확인
- 기존 memory limit 256Mi에 실제 사용량이 근접해 readiness timeout이 반복됨
- live Deployment는 우선 `request=192Mi`, `limit=512Mi`로 패치해 접속 복구 완료

## 변경
- `values-kube-prometheus-stack.yaml`의 Grafana memory request를 128Mi → 192Mi로 상향
- Grafana memory limit을 256Mi → 512Mi로 상향
- 다음 Helm 재적용 시에도 live 복구 설정이 유지되도록 values 기준 정합성 반영

## 검증
- `helm template kube-prometheus-stack prometheus-community/kube-prometheus-stack --version 84.4.0 -n monitoring -f k8s/monitoring/values-kube-prometheus-stack.yaml`
- rendered manifest에서 Grafana `memory: 512Mi`, `memory: 192Mi` 반영 확인
- live Deployment에서 `grafana request=192Mi limit=512Mi` 확인
- Grafana 대시보드 URL이 `503` 대신 `/login?redirectTo=%2Fd%2Fopentraum-gpu`로 `302 Found` 반환 확인
